### PR TITLE
Don't use parentheses for 0-arity defs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@
 ### Syntax
 
 * <a name="fun-parens"></a>
-  Always use parentheses around `def` arguments, don't omit them even when a function has no arguments.
+  Always use parentheses around `def` arguments if the function takes one
+  or more arguments. If the function doesn't take any arguments, don't use
+  parentheses.
   <sup>[[link](#fun-parens)]</sup>
 
   ```elixir
@@ -129,7 +131,7 @@
     #...
   end
 
-  def main do
+  def main() do
     #...
   end
 
@@ -138,7 +140,7 @@
     #...
   end
 
-  def main() do
+  def main do
     #...
   end
   ```


### PR DESCRIPTION
This is style used in the overwhelming majority of Elixir source code and Elixir code in the wild. I haven't a strong opinion on which one is the right one, but again I'd say 99% of the code I read (and wrote tbh) doesn't use parens for 0-arity `def`s (most of this code is Elixir source code btw).

What do you think?
