### PR TITLE
Update the rule on indentation of when clauses

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@
   ```
 
 * <a name="guard-clauses"></a>
-  Indent `when` guard clauses as much as the function definitions they apply to.
+  Indent `when` guard clauses **two levels** more than the function definition they apply to.
   <sup>[[link](#guard-clauses)]</sup>
 
   ```elixir
   def format_error({exception, stacktrace})
-  when is_list(stacktrace) and stacktrace != [] do
+      when is_list(stacktrace) and stacktrace != [] do
     #...
   end
   ```


### PR DESCRIPTION
I was thinking that maybe we should turn the `format_error/1` in the example to `defp` so that we show that the indentation is just two levels, otherwise I'm afraid it could be mistaken for indenting to the function name. Wdyt? \cc @lexmag 
