### PR TITLE
Fix small typo in section about guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@
     # ...
   end
 
-  defmacro dngettext(domain, msgid, msgid_plural, count) do
+  defmacro dngettext(domain, msgid, msgid_plural, count)
            when is_binary(msgid) and is_binary(msgid_plural) do
     # ...
   end


### PR DESCRIPTION
There was an extranous `do` in the example for guard clause indentation (accidently introduced in the last commit).

Keep up the good work! :+1:
