### PR TITLE
Add rule about "with" indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@
   end
   ```
 
-  Always use the indentation above if there's an `else` clause. If there isn't, the following indentation works as well:
+  Always use the indentation above if there's an `else` option. If there isn't, the following indentation works as well:
 
   ```elixir
   with {:ok, date} <- Calendar.ISO.date(year, month, day),

--- a/README.md
+++ b/README.md
@@ -268,6 +268,29 @@
   mailbox
   ```
 
+* <a name="with-indentation"></a>
+  Use the indentations shown below for the `with` special form:
+  <sup>[[link](#with-indentation)]</sup>
+
+  ```elixir
+  with {year, ""} <- Integer.parse(year),
+       {month, ""} <- Integer.parse(month),
+       {day, ""} <- Integer.parse(day) do
+    new(year, month, day)
+  else
+    _ ->
+      {:error, :invalid_format}
+  end
+  ```
+
+  Always use the indentation above if there's an `else` clause. If there isn't, the following indentation works as well:
+
+  ```elixir
+  with {:ok, date} <- Calendar.ISO.date(year, month, day),
+       {:ok, time} <- Time.new(hour, minute, second, microsecond),
+    do: new(date, time)
+  ```
+
 * <a name="no-else-with-unless"></a>
   Never use `unless` with `else`. Rewrite these with the positive case first.
   <sup>[[link](#no-else-with-unless)]</sup>

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@
   ```elixir
   with {:ok, date} <- Calendar.ISO.date(year, month, day),
        {:ok, time} <- Time.new(hour, minute, second, microsecond),
-    do: new(date, time)
+       do: new(date, time)
   ```
 
 * <a name="no-else-with-unless"></a>


### PR DESCRIPTION
The thing is: in Elixir, the most used indentation is:

```elixir
with pattern <- expr,
     ...,
     do: result
```

so the `:do` is indented differently than this guide. I personally prefer the indentation in this PR, but maybe is worth discussing. The discussion would apply to `for` as well.