### PR TITLE
Add a "Typespecs" section to the guide with a rule about parens

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,9 +650,9 @@
 
 ### Typespecs
 
-* <a name="parens-in-0-arity-types"></a>
-  Never use parens on 0-arity types.
-  <sup>[[link](#parens-in-0-arity-types)]</sup>
+* <a name="parens-in-zero-arity-types"></a>
+  Never use parens on zero-arity types.
+  <sup>[[link](#parens-in-zero-arity-types)]</sup>
 
   ```elixir
   # Bad

--- a/README.md
+++ b/README.md
@@ -648,6 +648,19 @@
   Mix.raise "Could not find dependency"
   ```
 
+### Typespecs
+
+* <a name="parens-in-0-arity-types"></a>
+  Never use parens on 0-arity types.
+  <sup>[[link](#parens-in-0-arity-types)]</sup>
+
+  ```elixir
+  # Bad
+  @spec start_link(module(), term(), Keyword.t()) :: on_start()
+
+  # Good
+  @spec start_link(module, term, Keyword.t) :: on_start
+  ```
 
 ### ExUnit
 


### PR DESCRIPTION
For now the only rule in this section is about not using parens for 0-arity types.