### PR TITLE
Apply paren rule for one-arity functions in pipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,15 +266,15 @@
   String.downcase(String.strip(input))
 
   # Good
-  input |> String.strip |> String.downcase
-  String.strip(input) |> String.downcase
+  input |> String.strip() |> String.downcase()
+  String.strip(input) |> String.downcase()
   ```
 
   Use a single level of indentation for multi-line pipelines.
 
   ```elixir
   String.strip(input)
-  |> String.downcase
+  |> String.downcase()
   |> String.slice(1, 3)
   ```
 
@@ -284,7 +284,7 @@
 
   ```elixir
   # Bad
-  result = input |> String.strip
+  result = input |> String.strip()
 
   # Good
   result = String.strip(input)


### PR DESCRIPTION
I'm liking the rule introduced in PR #28 to use parentheses even for one-arity functions in pipes. Therefore, it seems appropriate to apply it consistently in the rest of the document.