### PR TITLE
Update multi-line assignment expression guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@
   ```
 
 * <a name="multi-line-expr-assignment"></a>
-  When assigning the result of a multi-line expression, do not preserve alignment of its parts.
+  When assigning the result of a multi-line expression, begin the expression on a new line.
   <sup>[[link](#multi-line-expr-assignment)]</sup>
 
   ```elixir
@@ -101,11 +101,12 @@
     Enum.map(files, &Path.expand(&1, path))
     |> Enum.partition(&File.exists?/1)
 
-  prefix = case base do
-    :binary -> "0b"
-    :octal -> "0o"
-    :hex -> "0x"
-  end
+  prefix = 
+    case base do
+      :binary -> "0b"
+      :octal -> "0o"
+      :hex -> "0x"
+    end
   ```
 
 * <a name="underscores-in-numerics"></a>


### PR DESCRIPTION
In the light of https://github.com/uohzxela/ex_format, and it's need to make a decision about how to format multi-line expressions, I thought I might make a suggestion..

I think it's reasonable to say that all multi-line assignment expressions should begin the expression on a new line. This improves the indentation alignment in some situations, and is in agreement with the existing guidance.

```elixir
prefix =
  case base do
    :binary -> "0b"
    :octal -> "0o"
    :hex -> "0x"
  end
```

I think this is an improvement because:
* `case` and `end` are now aligned
* Each clause is now properly indented inside the containing `case`

Thanks!