### PR TITLE
Add example for leading underscore in function names

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ The following section are automatically applied by the code formatter in Elixir 
     # ...
   end
 
+  defp _parse_contents(data) do
+    # ...
+  end
+
   # Good
   :no_match
   :error
@@ -206,6 +210,10 @@ The following section are automatically applied by the code formatter in Elixir 
   @version "0.0.1"
 
   def read_file(path) do
+    # ...
+  end
+
+  defp parse_contents(data) do
     # ...
   end
   ```

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The following section are automatically applied by the code formatter in Elixir 
     # ...
   end
 
-  defp _parse_contents(data) do
+  def _parse_contents(data) do
     # ...
   end
 
@@ -213,7 +213,8 @@ The following section are automatically applied by the code formatter in Elixir 
     # ...
   end
 
-  defp parse_contents(data) do
+  @doc false
+  def parse_contents(data) do
     # ...
   end
   ```


### PR DESCRIPTION
Add an example for leading underscores in function names. I've seen examples of python-like leading underscores in function names to denote a function is private to the module.